### PR TITLE
feat: LayoutWithNavbar 분리 및 Navbar 설정 Context 적용

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,16 +2,22 @@ import HomePage from './pages/HomePage';
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import LayoutWithNavbar from './layout/LayoutWithNavbar';
+import RootLayout from './layout/RootLayout';
 
 function App() {
   return (
     <>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<HomePage />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/signup" element={<SignupPage />} />
-          /** Protected Route 혹은 Private Route 구현 필요 */
+          <Route element={<RootLayout />}>
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignupPage />} />
+
+            <Route path="/" element={<LayoutWithNavbar />}>
+              <Route index element={<HomePage />} />
+            </Route>
+          </Route>
         </Routes>
       </BrowserRouter>
     </>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,23 @@
+import { useNavigate } from 'react-router-dom';
+import { useNavbar } from './NavbarContext';
+
+const NavBar = () => {
+  const { config } = useNavbar();
+  const navigate = useNavigate();
+
+  const handleBack = () => {
+    navigate('/login');
+  };
+
+  return (
+    <div className="flex h-14 items-center justify-between bg-gray-200 px-4">
+      <div onClick={handleBack} className="cursor-pointer text-2xl">
+        {config.showBack && <button>{'<'}</button>}
+      </div>
+      <div className="text-lg font-bold">{config.showTitle ? 'SERI VOCA' : ''}</div>
+      <div className="cursor-pointer text-2xl">{config.showSettings && <button>⚙️</button>}</div>
+    </div>
+  );
+};
+
+export default NavBar;

--- a/src/components/NavbarContext.tsx
+++ b/src/components/NavbarContext.tsx
@@ -1,0 +1,13 @@
+import { createContext, useContext } from 'react';
+
+interface NavbarContextType {
+  config: { showBack: boolean; showTitle: boolean; showSettings: boolean };
+  setConfig: (config: { showBack: boolean; showTitle: boolean; showSettings: boolean }) => void;
+}
+
+export const NavbarContext = createContext<NavbarContextType>({
+  config: { showBack: false, showTitle: true, showSettings: false },
+  setConfig: () => {},
+});
+
+export const useNavbar = () => useContext(NavbarContext);

--- a/src/layout/Layout.tsx
+++ b/src/layout/Layout.tsx
@@ -1,9 +1,0 @@
-interface LayoutProps {
-  children: React.ReactNode;
-}
-
-const Layout: React.FC<LayoutProps> = ({ children }) => {
-  return <div className="h-[844px] w-[390px]">{children}</div>;
-};
-
-export default Layout;

--- a/src/layout/LayoutWithNavbar.tsx
+++ b/src/layout/LayoutWithNavbar.tsx
@@ -1,0 +1,23 @@
+import { Outlet } from 'react-router-dom';
+import Navbar from '../components/Navbar';
+import { useState } from 'react';
+import { NavbarContext } from '../components/NavbarContext';
+
+const LayoutWithNavbar = () => {
+  const [config, setConfig] = useState({
+    showBack: false,
+    showTitle: true,
+    showSettings: false,
+  });
+
+  return (
+    <NavbarContext.Provider value={{ config, setConfig }}>
+      <div className="flex h-full flex-col">
+        <Navbar />
+        <Outlet />
+      </div>
+    </NavbarContext.Provider>
+  );
+};
+
+export default LayoutWithNavbar;

--- a/src/layout/RootLayout.tsx
+++ b/src/layout/RootLayout.tsx
@@ -1,0 +1,12 @@
+import { Outlet } from 'react-router-dom';
+
+const RootLayout = () => {
+  return (
+    <div className="h-[844px] w-[390px]">
+      {/* 모든 페이지 공통 사이즈 및 배경 등 */}
+      <Outlet />
+    </div>
+  );
+};
+
+export default RootLayout;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,12 +2,9 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
-import Layout from './layout/Layout.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <Layout>
-      <App />
-    </Layout>
+    <App />
   </StrictMode>
 );

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -1,6 +1,14 @@
+import { useEffect } from 'react';
 import DayButton from '../components/DayButton';
+import { useNavbar } from '../components/NavbarContext';
 
 const HomePage = () => {
+  const { setConfig } = useNavbar();
+
+  useEffect(() => {
+    setConfig({ showBack: false, showTitle: true, showSettings: true });
+  }, []);
+
   return (
     <div className="flex h-dvh items-center justify-center">
       <div className="flex h-120 flex-col gap-4 overflow-y-scroll p-2">

--- a/src/pages/SignupPage.tsx
+++ b/src/pages/SignupPage.tsx
@@ -32,6 +32,7 @@ type SignupFields = z.infer<typeof schema>;
 
 const SignupPage = () => {
   const navigate = useNavigate();
+
   // useForm
   const {
     register,
@@ -57,6 +58,11 @@ const SignupPage = () => {
 
   return (
     <div className="flex h-dvh flex-col items-center justify-center gap-5">
+      <div className="fixed top-0 flex h-14 w-full items-center gap-2 px-4">
+        <div onClick={() => navigate('/login')} className="cursor-pointer text-xl">
+          {'< 로그인'}
+        </div>
+      </div>
       <h1 className="mb-10 flex text-center text-6xl">
         SERI
         <br />


### PR DESCRIPTION
- RootLayout과 LayoutWithNavbar 분리
- 로그인, 회원가입 페이지 -> RootLayout
- 홈페이지 -> LayoutWithNavbar
- Navbar 요소 : useState, Context 전역 상태 관리
- useState : 뒤로가기, 타이틀, 세팅 옵션 설정 가능